### PR TITLE
Add a CMakeLists.txt to allow FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(phnt)
+
+add_library(phnt INTERFACE)
+target_include_directories(phnt INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
+target_link_libraries(phnt INTERFACE "ntdll.lib")
+
+add_library(phnt::phnt ALIAS phnt)


### PR DESCRIPTION
With this it becomes very easy to include phnt in a CMake-based project. If you add phnt a a submodule or vendor it in a different way:

```cmake
add_subdirectory(third_party/phnt)
```

Download automatically during configuration:

```cmake
include(FetchContent)

message(STATUS "Fetching phnt (cmake)...")
FetchContent_Declare(phnt
	GIT_REPOSITORY
		"https://github.com/mrexodia/phnt"
	GIT_TAG
		cmake
)
FetchContent_MakeAvailable(phnt)
```

In both cases you can link to phnt this way:

```cmake
add_executable(native_example src/main.cpp)
target_link_libraries(native_example PRIVATE phnt::phnt) # or just phnt
```

If desired I can set up GitHub Actions that tests this.