### PR TITLE
Fix `RtlCopyVolatileMemory` declaration conflicts

### DIFF
--- a/ntrtl.h
+++ b/ntrtl.h
@@ -1258,18 +1258,20 @@ RtlWakeAddressSingle(
 // end_rev
 
 #if (PHNT_VERSION >= PHNT_WIN11_22H2)
+#ifdef _RTL_VOL_MEM_ACCESSORS_
 FORCEINLINE
-VOID
-NTAPI
+volatile void*
+__cdecl
 RtlCopyVolatileMemory(
-    _Out_writes_bytes_(Size) VOID *Destination,
-    _In_reads_bytes_(Size) volatile const VOID *Source,
-    _In_ SIZE_T Size
+    _Out_writes_bytes_all_(Length) volatile void* Destination,
+    _In_reads_bytes_(Length) volatile const void* Source,
+    _In_ size_t Length
     )
 {
-    RtlCopyMemory(Destination, (const VOID *)Source, Size);
+    RtlCopyMemory((VOID*)Destination, (const VOID *)Source, Length);
     BarrierAfterRead();
 }
+#endif
 #endif
 
 FORCEINLINE

--- a/ntrtl.h
+++ b/ntrtl.h
@@ -1257,33 +1257,6 @@ RtlWakeAddressSingle(
 
 // end_rev
 
-#if (PHNT_VERSION >= PHNT_WIN11_22H2)
-#ifdef _RTL_VOL_MEM_ACCESSORS_
-FORCEINLINE
-volatile void*
-__cdecl
-RtlCopyVolatileMemory(
-    _Out_writes_bytes_all_(Length) volatile void* Destination,
-    _In_reads_bytes_(Length) volatile const void* Source,
-    _In_ size_t Length
-    )
-{
-    RtlCopyMemory((VOID*)Destination, (const VOID *)Source, Length);
-    BarrierAfterRead();
-}
-#endif
-#endif
-
-FORCEINLINE
-HANDLE
-NTAPI
-RtlReadHandleNoFence(
-    _In_reads_bytes_(sizeof(HANDLE)) volatile CONST HANDLE *Address
-    )
-{
-    return (HANDLE)ReadPointerNoFence((PVOID *)Address);
-}
-
 // Strings
 
 FORCEINLINE


### PR DESCRIPTION
On the latest SDK (10.0.26100.0), `winnt.h` defined:
```C
#ifndef _RTL_VOL_MEM_ACCESSORS_
#define _RTL_VOL_MEM_ACCESSORS_

...

volatile void*
__cdecl
RtlCopyVolatileMemory (
    _Out_writes_bytes_all_(Length) volatile void* Destination,
    _In_reads_bytes_(Length) volatile const void* Source,
    _In_ size_t Length
    );

...

#endif
```
Which the declaration is different from current phnt and guarded by `_RTL_VOL_MEM_ACCESSORS_` macro.
This change will fix a compile-time error:
`Error C2040 'RtlCopyVolatileMemory': 'void (void *,volatile const void *,SIZE_T)' differs in levels of indirection from 'volatile void *(volatile void *,volatile const void *,size_t)'`, which is occurred in [Issue #36](https://github.com/winsiderss/phnt/issues/36), reported in the first line.