### PR TITLE
Fix symbol member names in `_LDR_DATA_TABLE_ENTRY`

### DIFF
--- a/ntldr.h
+++ b/ntldr.h
@@ -141,9 +141,9 @@ typedef struct _LDRP_LOAD_CONTEXT *PLDRP_LOAD_CONTEXT;
 // symbols
 typedef struct _LDR_DATA_TABLE_ENTRY
 {
-    LIST_ENTRY InLoadOrderLinks;
-    LIST_ENTRY InMemoryOrderLinks;
-    LIST_ENTRY InInitializationOrderLinks;
+    LIST_ENTRY InLoadOrderModuleList;
+    LIST_ENTRY InMemoryOrderModuleList;
+    LIST_ENTRY InInitializationOrderModuleList;
     PVOID DllBase;
     PLDR_INIT_ROUTINE EntryPoint;
     ULONG SizeOfImage;

--- a/ntwow64.h
+++ b/ntwow64.h
@@ -108,8 +108,8 @@ typedef struct _LDR_DDAG_NODE32
 
 typedef struct _LDR_DATA_TABLE_ENTRY32
 {
-    LIST_ENTRY32 InLoadOrderLinks;
-    LIST_ENTRY32 InMemoryOrderLinks;
+    LIST_ENTRY32 InLoadOrderModuleList;
+    LIST_ENTRY32 InMemoryOrderModuleList;
     union
     {
         LIST_ENTRY32 InInitializationOrderLinks;


### PR DESCRIPTION
The latest symbol information `dt _LDR_DATA_TABLE_ENTRY`:
```C
   +0x000 InLoadOrderModuleList : _LIST_ENTRY
   +0x010 InMemoryOrderModuleList : _LIST_ENTRY
   +0x020 InInitializationOrderModuleList : _LIST_ENTRY
   +0x030 DllBase          : Ptr64 HINSTANCE__
   +0x038 EntryPoint       : Ptr64 Void
   +0x040 SizeOfImage      : Uint4B
   +0x048 FullDllName      : _UNICODE_STRING
   +0x058 BaseDllName      : _UNICODE_STRING
   ...
```