### PR TITLE
Add `MAXUCHAR`, `MAXUSHORT` and `MAXULONG`

### DIFF
--- a/phnt_ntdef.h
+++ b/phnt_ntdef.h
@@ -55,6 +55,12 @@ typedef PCSTR PCSZ;
 
 typedef PVOID* PPVOID;
 
+// Limits
+
+#define MAXUCHAR 0xff
+#define MAXUSHORT 0xffff
+#define MAXULONG 0xffffffff
+
 // Specific
 
 typedef UCHAR KIRQL, *PKIRQL;


### PR DESCRIPTION
They're present in `ntdef.h` but not present in `winnt.h`, add them to phnt's ntdef.h.