### PR TITLE
Fix type of `RTL_USER_PROCESS_PARAMETERS::DefaultThreadpoolCpuSetMasks`

### DIFF
--- a/ntrtl.h
+++ b/ntrtl.h
@@ -2852,7 +2852,7 @@ typedef struct _RTL_USER_PROCESS_PARAMETERS
 
     UNICODE_STRING RedirectionDllName; // REDSTONE4
     UNICODE_STRING HeapPartitionName; // 19H1
-    ULONG_PTR DefaultThreadpoolCpuSetMasks;
+    PULONGLONG DefaultThreadpoolCpuSetMasks;
     ULONG DefaultThreadpoolCpuSetMaskCount;
     ULONG DefaultThreadpoolThreadMaximum;
     ULONG HeapMemoryTypeMask; // WIN11

--- a/ntwow64.h
+++ b/ntwow64.h
@@ -240,7 +240,7 @@ typedef struct _RTL_USER_PROCESS_PARAMETERS32
 
     UNICODE_STRING32 RedirectionDllName; // REDSTONE4
     UNICODE_STRING32 HeapPartitionName; // 19H1
-    WOW64_POINTER(ULONG_PTR) DefaultThreadpoolCpuSetMasks;
+    WOW64_POINTER(ULONGLONG) DefaultThreadpoolCpuSetMasks;
     ULONG DefaultThreadpoolCpuSetMaskCount;
     ULONG DefaultThreadpoolThreadMaximum;
 } RTL_USER_PROCESS_PARAMETERS32, *PRTL_USER_PROCESS_PARAMETERS32;


### PR DESCRIPTION
It's a pointer point to `ULONGLONG`, not `ULONG_PTR`. See symbol:
```
64-bit:
ntdll!_RTL_USER_PROCESS_PARAMETERS
   ...
   +0x430 DefaultThreadpoolCpuSetMasks : Ptr64 Uint8B
   ...

32-bit:
ntdll!_RTL_USER_PROCESS_PARAMETERS
   ...
   +0x2b4 DefaultThreadpoolCpuSetMasks : Ptr32 Uint8B
   ...
```