### PR TITLE
Fix _EXCEPTION_RECORD type

### DIFF
--- a/ntrtl.h
+++ b/ntrtl.h
@@ -9717,7 +9717,7 @@ VOID
 __cdecl
 RtlRestoreContext(
     _In_ PCONTEXT ContextRecord,
-    _In_opt_ struct _EXCEPTION_RECORD* ExceptionRecord
+    _In_opt_ PEXCEPTION_RECORD ExceptionRecord
     );
 #endif
 


### PR DESCRIPTION
Seems to be a historical typo from MS, which has spread to MSDN and many public headers.
The type has been unified with similar functions.

There are also examples of the correct signature in other projects (see https://github.com/reactos/reactos/blob/773206851a54318fc27519ea575e478250fcc960/sdk/lib/rtl/amd64/unwind.c#L1284-L1286)